### PR TITLE
feat(media-player): add PiP mode

### DIFF
--- a/packages/app-plyr/src/player.svelte
+++ b/packages/app-plyr/src/player.svelte
@@ -30,7 +30,7 @@
       }
       player = new Plyr(player_element, {
         fullscreen: { enabled: false },
-        controls: ["play", "progress", "current-time", "mute", "volume"],
+        controls: ["play", "progress", "current-time", "mute", "volume", "pip"],
         clickToPlay: false,
         youtube: { autoplay: true },
         loadSprite: false,


### PR DESCRIPTION
Add PiP control to the media player.

Tested on both Safari and Google Chrome, works well.

### Preview

<img width="881" alt="CleanShot 2022-09-22 at 15 16 38@2x" src="https://user-images.githubusercontent.com/8186898/191682743-27a75bd3-acec-40d5-add8-2bd67750dd28.png">
