### PR TITLE
chore: Add typing for additional GeoGebra API calls

### DIFF
--- a/packages/app-geogebra/src/types/api.ts
+++ b/packages/app-geogebra/src/types/api.ts
@@ -33,6 +33,7 @@ export interface AppletObject {
   startSaveCallback(title: string, visibility: string, callbackAction: string): void;
   initCAS(): void;
   setErrorDialogsActive(flag: boolean): void;
+  setCoordSystem(xmin: number, xmax: number, ymin: number, ymax: number, zmin?: number, zmax?: number, yVertical?: boolean): void;
   reset(): void;
   refreshViews(): void;
   setVisible(objName: string, visible: boolean): void;
@@ -181,6 +182,8 @@ export interface AppletObject {
   getScreenReaderOutput(text: string): string;
   getEditorState(): string;
   setEditorState(state: string, label: string): void;
+  getGraphicsOptions(viewId: number): GraphicsOptions;
+  setGraphicsOptions(viewId: number, options: string | RecursivePartial<GraphicsOptions>): void;
   translate(arg1: string, callback: (data: string) => void): string;
   exportConstruction(flags: string[]): string;
   updateConstruction(): void;
@@ -239,6 +242,38 @@ export interface AppletObject {
   lockTextElement(label: string): void;
   unlockTextElement(label: string): void;
 }
+
+export type AxisConfiguration = {
+  label: string | null,
+  unitLabel: string | null,
+  positiveAxis: boolean,
+  showNumbers: boolean,
+  tickStyle: number,
+  visible: boolean
+}
+
+export type AxesConfiguration = {
+  x: AxisConfiguration,
+  y: AxisConfiguration,
+  z: AxisConfiguration
+}
+
+export type GraphicsOptions = {
+  axesColor: string,
+  bgColor: string,
+  gridColor: string,
+  axes: AxesConfiguration,
+  grid: boolean,
+  gridDistance: {x: number | null, y: number | null},
+  gridType: number,
+  pointCapturing: number,
+  rightAngleStyle: number,
+  rulerType: number
+}
+
+type RecursivePartial<T> = {
+  [P in keyof T]?: RecursivePartial<T[P]>;
+};
 
 /**
  * @link https://wiki.geogebra.org/en/Reference:GeoGebra_Apps_API#Client_Events

--- a/packages/app-geogebra/src/types/api.ts
+++ b/packages/app-geogebra/src/types/api.ts
@@ -33,7 +33,15 @@ export interface AppletObject {
   startSaveCallback(title: string, visibility: string, callbackAction: string): void;
   initCAS(): void;
   setErrorDialogsActive(flag: boolean): void;
-  setCoordSystem(xmin: number, xmax: number, ymin: number, ymax: number, zmin?: number, zmax?: number, yVertical?: boolean): void;
+  setCoordSystem(
+    xmin: number,
+    xmax: number,
+    ymin: number,
+    ymax: number,
+    zmin?: number,
+    zmax?: number,
+    yVertical?: boolean
+  ): void;
   reset(): void;
   refreshViews(): void;
   setVisible(objName: string, visible: boolean): void;
@@ -244,32 +252,32 @@ export interface AppletObject {
 }
 
 export type AxisConfiguration = {
-  label: string | null,
-  unitLabel: string | null,
-  positiveAxis: boolean,
-  showNumbers: boolean,
-  tickStyle: number,
-  visible: boolean
-}
+  label: string | null;
+  unitLabel: string | null;
+  positiveAxis: boolean;
+  showNumbers: boolean;
+  tickStyle: number;
+  visible: boolean;
+};
 
 export type AxesConfiguration = {
-  x: AxisConfiguration,
-  y: AxisConfiguration,
-  z: AxisConfiguration
-}
+  x: AxisConfiguration;
+  y: AxisConfiguration;
+  z: AxisConfiguration;
+};
 
 export type GraphicsOptions = {
-  axesColor: string,
-  bgColor: string,
-  gridColor: string,
-  axes: AxesConfiguration,
-  grid: boolean,
-  gridDistance: {x: number | null, y: number | null},
-  gridType: number,
-  pointCapturing: number,
-  rightAngleStyle: number,
-  rulerType: number
-}
+  axesColor: string;
+  bgColor: string;
+  gridColor: string;
+  axes: AxesConfiguration;
+  grid: boolean;
+  gridDistance: { x: number | null; y: number | null };
+  gridType: number;
+  pointCapturing: number;
+  rightAngleStyle: number;
+  rulerType: number;
+};
 
 type RecursivePartial<T> = {
   [P in keyof T]?: RecursivePartial<T[P]>;


### PR DESCRIPTION
There are additional GeoGebra calls documented in the [referenced link](https://wiki.geogebra.org/en/Reference:GeoGebra_Apps_API) that have not yet been typed in these DTS files. This PR adds the ones I encountered. I realize they may not be used in this app, but on the other hand, these were the only DTS files I could find for the deployggb.js script provided by GeoGebra, anywhere on the web. So I extract them from this repo in my build process. I can of course patch them, but it would be easier if the upstream ones were complete. So I thought I would offer this PR. Might you consider contributing just the deployggb.js typings to DefinitelyTyped as a standalone package? That way anyone attempting to create a GeoGebra applet from TypeScript could use them. Just a thought.

Thanks so much for having made these typings, they saved me a lot of work.