### PR TITLE
fix(slide): serialize frozen state recovery

### DIFF
--- a/packages/app-slide/__tests__/recovery.test.js
+++ b/packages/app-slide/__tests__/recovery.test.js
@@ -1,0 +1,88 @@
+const assert = require("assert");
+const fs = require("fs");
+const ts = require("typescript");
+
+const originalTypeScriptExtension = require.extensions[".ts"];
+require.extensions[".ts"] = (module, filename) => {
+  const source = fs.readFileSync(filename, "utf8");
+  const output = ts.transpileModule(source, {
+    compilerOptions: {
+      esModuleInterop: true,
+      module: ts.ModuleKind.CommonJS,
+      target: ts.ScriptTarget.ES2018,
+    },
+    fileName: filename,
+  }).outputText;
+  module._compile(output, filename);
+};
+
+const { releaseAndRestoreSlide } = require("../src/SlideController/recovery.ts");
+
+if (originalTypeScriptExtension) {
+  require.extensions[".ts"] = originalTypeScriptExtension;
+} else {
+  delete require.extensions[".ts"];
+}
+
+async function run() {
+  const events = [];
+  let completeRelease;
+  let completeRestore;
+  let latestState = { page: 1 };
+  const slide = {
+    release: callback => {
+      events.push("release:start");
+      completeRelease = callback;
+    },
+    setSlideState: state => {
+      events.push(`restore:${state.page}`);
+      return new Promise(resolve => {
+        completeRestore = () => {
+          events.push("restore:complete");
+          resolve();
+        };
+      });
+    },
+  };
+
+  const recovery = releaseAndRestoreSlide(
+    slide,
+    () => {
+      events.push("storage:read");
+      return latestState;
+    },
+    state => events.push(`storage:apply:${state.page}`)
+  );
+
+  assert.deepStrictEqual(events, ["release:start"]);
+  latestState = { page: 3 };
+  completeRelease();
+
+  let recoveryCompleted = false;
+  recovery.then(() => {
+    recoveryCompleted = true;
+  });
+  await Promise.resolve();
+
+  assert.deepStrictEqual(events, ["release:start", "storage:read", "storage:apply:3", "restore:3"]);
+  assert.strictEqual(recoveryCompleted, false);
+
+  completeRestore();
+  await recovery;
+
+  assert.strictEqual(recoveryCompleted, true);
+  assert.deepStrictEqual(events, [
+    "release:start",
+    "storage:read",
+    "storage:apply:3",
+    "restore:3",
+    "restore:complete",
+  ]);
+
+  console.log("app-slide recovery tests passed");
+}
+
+run().catch(error => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/packages/app-slide/package.json
+++ b/packages/app-slide/package.json
@@ -5,6 +5,7 @@
   "module": "dist/main.es.js",
   "types": "dist/index.d.ts",
   "scripts": {
+    "test": "node __tests__/recovery.test.js",
     "types": "node scripts/build-types.mjs",
     "build": "vite build && npm run types",
     "build:dev": "vite build --mode development && npm run types",

--- a/packages/app-slide/src/SlideController/index.ts
+++ b/packages/app-slide/src/SlideController/index.ts
@@ -19,6 +19,7 @@ import { clamp } from "../utils/helpers";
 import { cachedGetBgColor } from "../utils/bgcolor";
 import { log, verbose, setRoomLogger } from "../utils/logger";
 import { getRoomTracker } from "../utils/tracker";
+import { releaseAndRestoreSlide } from "./recovery";
 export { syncSceneWithSlide, createDocsViewerPages } from "./helpers";
 
 export const DefaultUrl = "https://convertcdn.netless.link/dynamicConvert";
@@ -392,20 +393,20 @@ export class SlideControllerBase {
     if (!this.visible) return;
     this.isFrozen = false;
     if (this.ready) {
-      let isNeedSyncState = false;
       log("[Slide] unfreeze", this.context.appId);
-      if (this.invisibleBehavior === "frozen") {
-        this.slide.release();
-        isNeedSyncState = true;
-      } else {
-        this.slide.resume();
-      }
-      if (isNeedSyncState) {
-        const state = this.context.storage.state.state;
-        if (state) {
-          log("[Slide] sync storage", JSON.stringify(state));
-          this.slide.setSlideState(state);
+      try {
+        if (this.invisibleBehavior !== "frozen") {
+          this.slide.resume();
+          return;
         }
+
+        await releaseAndRestoreSlide(
+          this.slide,
+          () => this.context.storage.state.state,
+          state => log("[Slide] sync storage", JSON.stringify(state))
+        );
+      } catch (error) {
+        log("[Slide] unfreeze failed", error);
       }
     } else {
       this._toFreeze = -1;

--- a/packages/app-slide/src/SlideController/recovery.ts
+++ b/packages/app-slide/src/SlideController/recovery.ts
@@ -1,0 +1,17 @@
+export interface RecoverableSlide<State> {
+  release: (callback: () => void) => void;
+  setSlideState: (state: State) => Promise<void>;
+}
+
+export async function releaseAndRestoreSlide<State>(
+  slide: RecoverableSlide<State>,
+  getLatestState: () => State | null | undefined,
+  onRestore?: (state: State) => void
+): Promise<void> {
+  await new Promise<void>(resolve => slide.release(resolve));
+  const state = getLatestState();
+  if (state) {
+    onRestore?.(state);
+    await slide.setSlideState(state);
+  }
+}


### PR DESCRIPTION
## Summary

- wait for Slide release completion before reading shared storage
- re-read and apply the latest shared slide state after release
- await the final `setSlideState()` call and log recovery failures
- add a regression test for both call order and completion order

## Verification

- `node packages/app-slide/__tests__/recovery.test.js`
- targeted ESLint and Prettier checks
- `npm run build:dev --prefix packages/app-slide`

## Dependency note

`@netless/app-slide` currently pins `@netless/slide@1.4.54`. Merge and publish the corresponding Slide private-freeze-state fix first, then update the dependency version in a separate release commit. Historical rooms that already contain `frozenTime` are intentionally not filtered by this change.