### PR TITLE
fix(app-slide): notify slide resize after scaleView and unfreeze

### DIFF
--- a/packages/app-slide/package.json
+++ b/packages/app-slide/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@netless/app-slide",
-  "version": "0.2.102",
+  "version": "0.2.103",
   "main": "dist/main.cjs.js",
   "module": "dist/main.es.js",
   "types": "dist/index.d.ts",
@@ -16,7 +16,7 @@
     "README-zh.md"
   ],
   "devDependencies": {
-    "@netless/slide": "1.4.56",
+    "@netless/slide": "1.4.57",
     "@types/color-string": "^1.5.2",
     "color-string": "^1.9.1",
     "jspdf": "2.5.1",

--- a/packages/app-slide/package.json
+++ b/packages/app-slide/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@netless/app-slide",
-  "version": "0.2.101",
+  "version": "0.2.102",
   "main": "dist/main.cjs.js",
   "module": "dist/main.es.js",
   "types": "dist/index.d.ts",

--- a/packages/app-slide/package.json
+++ b/packages/app-slide/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@netless/app-slide",
-  "version": "0.2.100",
+  "version": "0.2.101",
   "main": "dist/main.cjs.js",
   "module": "dist/main.es.js",
   "types": "dist/index.d.ts",
@@ -16,7 +16,7 @@
     "README-zh.md"
   ],
   "devDependencies": {
-    "@netless/slide": "1.4.55",
+    "@netless/slide": "1.4.56",
     "@types/color-string": "^1.5.2",
     "color-string": "^1.9.1",
     "jspdf": "2.5.1",

--- a/packages/app-slide/playground.ts
+++ b/packages/app-slide/playground.ts
@@ -12,6 +12,7 @@ function definePPT(
   return {
     kind: "Slide",
     src: () => import("./src"),
+    appOptions: { enableScale: true },
     options: { title, scenePath: `/Slide/${taskId}/${title}` },
     attributes: { taskId, url, customLinks },
     addHooks,

--- a/packages/app-slide/src/DocsViewer/ResizableContainer.ts
+++ b/packages/app-slide/src/DocsViewer/ResizableContainer.ts
@@ -9,6 +9,7 @@ export class ResizableContainer {
   public container: HTMLDivElement;
   private scrollContainer: HTMLDivElement;
   public onScaleChanged: ((scale: number) => void) | null = null;
+  public onLayoutUpdated: (() => void) | null = null;
 
   private parent: HTMLElement;
   private whiteboardContainer: HTMLDivElement | null = null;
@@ -131,6 +132,12 @@ export class ResizableContainer {
       triggerScrollBar: true,
       triggerSync: true,
     });
+
+    // enableScale / scaleView 只改变内部 container 的像素尺寸，box 本身不变。
+    // Slide 内部 ResizeObserver 已关闭，box 上的 observer / boxSizeChange 都不会触发，
+    // 必须在这里主动通知 canvas 按新的 frame 尺寸重绘。
+    this.slide?.notifyFrameResize();
+    this.onLayoutUpdated?.();
   }
 
   // x, y 范围 0 ~ 1
@@ -199,6 +206,7 @@ export class ResizableContainer {
   }
 
   public destroy(_box?: ReadonlyTeleBox): void {
+    this.onLayoutUpdated = null;
     this.scrollBar?.destroy();
   }
 }

--- a/packages/app-slide/src/SlideController/index.ts
+++ b/packages/app-slide/src/SlideController/index.ts
@@ -398,10 +398,14 @@ export class SlideControllerBase {
       let isNeedSyncState = false;
       log("[Slide] unfreeze", this.context.appId);
       if (this.invisibleBehavior === "frozen") {
-        this.slide.release();
+        this.slide.release(() => {
+          // release 会重建 player，内部 observer 已关闭，需要按当前 frame 尺寸重绘
+          this.slide.notifyFrameResize();
+        });
         isNeedSyncState = true;
       } else {
         this.slide.resume();
+        this.slide.notifyFrameResize();
       }
       if (isNeedSyncState) {
         const state = this.context.storage.state.state;

--- a/packages/app-slide/src/SlideDocsViewer/index.ts
+++ b/packages/app-slide/src/SlideDocsViewer/index.ts
@@ -223,6 +223,9 @@ export class SlideDocsViewer {
         this.enableScale,
         this.box,
       );
+      this.resizableContainer.onLayoutUpdated = () => {
+        this.scaleDocsToFit();
+      };
     }
 
     // 创建元素

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -254,8 +254,8 @@ importers:
         specifier: ^3.3.1
         version: 3.4.0
       '@netless/slide':
-        specifier: 1.4.55
-        version: 1.4.55
+        specifier: 1.4.56
+        version: 1.4.56
       '@types/color-string':
         specifier: ^1.5.2
         version: 1.5.5
@@ -504,8 +504,8 @@ packages:
   '@netless/canvas-polyfill@0.0.4':
     resolution: {integrity: sha512-7NzsJrba0R/mq/l10SkIZQwbrNVJyPxZYrjK6xL3Ts732iWAVuS2UB0u3s6iGeUVcqV39A679yva8APWRl4M0A==}
 
-  '@netless/slide@1.4.55':
-    resolution: {integrity: sha512-KcfdKTy3bMgVyAVM13s5cwhx3Sr9vZfH4epdJlQ4Fp0XhgEi1Ve3YOXImW/MZgzbahxXhpYY+FbCAjdQeOhlmg==}
+  '@netless/slide@1.4.56':
+    resolution: {integrity: sha512-2K/EPHpubypRYz5mQAuK7t4DD7l8jpyJWp8f34uzgrHwdCiJg0iGHI5yVEmL8/QEWxn7MAGqLwgw68YYOw5xgw==}
 
   '@netless/telebox-insider@0.2.28':
     resolution: {integrity: sha512-UJDCm/f7yjiIaWqbS20LDXfAG6RUxsXSktPDzmEr51MgsevpQ3u241hVlyOpKAXSeTR6B3ioRAKcgflOw5JvTQ==}
@@ -2683,7 +2683,7 @@ snapshots:
 
   '@netless/canvas-polyfill@0.0.4': {}
 
-  '@netless/slide@1.4.55':
+  '@netless/slide@1.4.56':
     dependencies:
       '@juggle/resize-observer': 3.4.0
       '@types/lodash': 4.17.23

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -254,8 +254,8 @@ importers:
         specifier: ^3.3.1
         version: 3.4.0
       '@netless/slide':
-        specifier: 1.4.56
-        version: 1.4.56
+        specifier: 1.4.57
+        version: 1.4.57
       '@types/color-string':
         specifier: ^1.5.2
         version: 1.5.5
@@ -504,8 +504,8 @@ packages:
   '@netless/canvas-polyfill@0.0.4':
     resolution: {integrity: sha512-7NzsJrba0R/mq/l10SkIZQwbrNVJyPxZYrjK6xL3Ts732iWAVuS2UB0u3s6iGeUVcqV39A679yva8APWRl4M0A==}
 
-  '@netless/slide@1.4.56':
-    resolution: {integrity: sha512-2K/EPHpubypRYz5mQAuK7t4DD7l8jpyJWp8f34uzgrHwdCiJg0iGHI5yVEmL8/QEWxn7MAGqLwgw68YYOw5xgw==}
+  '@netless/slide@1.4.57':
+    resolution: {integrity: sha512-wBS8BMjOpPMtrCVdxCeZB5ZtAn0qhMY+ztawLaazQIjjtyPrW6Yb+evOwiLTV+CiECwTz4ZAn3w3jQZNDjMmLg==}
 
   '@netless/telebox-insider@0.2.28':
     resolution: {integrity: sha512-UJDCm/f7yjiIaWqbS20LDXfAG6RUxsXSktPDzmEr51MgsevpQ3u241hVlyOpKAXSeTR6B3ioRAKcgflOw5JvTQ==}
@@ -2683,7 +2683,7 @@ snapshots:
 
   '@netless/canvas-polyfill@0.0.4': {}
 
-  '@netless/slide@1.4.56':
+  '@netless/slide@1.4.57':
     dependencies:
       '@juggle/resize-observer': 3.4.0
       '@types/lodash': 4.17.23


### PR DESCRIPTION
Inner container scale and player rebuild do not change the box size, so the content observer never fires. Call notifyFrameResize explicitly after those layout updates.

Co-authored-by: Cursor <cursoragent@cursor.com>